### PR TITLE
Fix save token to mongodb

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -54,7 +54,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity)
     {
         $this->tokenRepository->create([
-            '_id' => $accessTokenEntity->getIdentifier(),
+            'id' => $accessTokenEntity->getIdentifier(),
             'user_id' => $accessTokenEntity->getUserIdentifier(),
             'client_id' => $accessTokenEntity->getClient()->getIdentifier(),
             'scopes' => $this->scopesToArray($accessTokenEntity->getScopes()),


### PR DESCRIPTION
When token generate was create token id **(jti)** this id need save to database, not in mongodb Object ID field.